### PR TITLE
add php5-style constructor

### DIFF
--- a/src/MailUp/MailUpClient.php
+++ b/src/MailUp/MailUpClient.php
@@ -17,6 +17,10 @@ class MailUpClient {
     var $accessToken;
     var $refreshToken;
 
+    function __construct($inClientId, $inClientSecret, $inCallbackUri) {
+        $this->MailUpClient($inClientId, $inClientSecret, $inCallbackUri);
+    }
+
     function getLogonEndpoint() {
         return $this->logonEndpoint;
     }


### PR DESCRIPTION
Hi,

with a namespaced class, old php4-constructor will not work (see https://wiki.php.net/rfc/remove_php4_constructors).
